### PR TITLE
Fix getActiveStateProgressForTime

### DIFF
--- a/src/framework/anim/controller/anim-controller.js
+++ b/src/framework/anim/controller/anim-controller.js
@@ -185,7 +185,8 @@ class AnimController {
 
         const activeClip = this._animEvaluator.findClip(this.activeStateAnimations[0].name);
         if (activeClip) {
-            return time / activeClip.track.duration;
+            const speed = this.activeStateAnimations[0].speed;
+            return (time * speed) / activeClip.track.duration;
         }
 
         return null;


### PR DESCRIPTION
I’ve noticed that AnimComponent’s activeStateProgress does not return 1 at the end when the speed is greater than 1.

I have an animation with a duration of 4.5 secs when the animation speed is 1 and I run activeStateProgress regularly and at the end, I get the result 1. But when I update the animation’s speed to for example 3, I get 0.26 at the end.